### PR TITLE
Travis CI build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+
+os:
+  - linux
+  - osx
+
+before_script:
+  - wget http://www.tortall.net/projects/yasm/releases/yasm-1.2.0.tar.gz
+  - tar xvzf yasm-1.2.0.tar.gz
+  - cd yasm-1.2.0
+  - ./configure && make -j 4 && sudo make install
+  - cd ..
+
+script:
+  - mkdir build && cd build
+  - cmake -DCMAKE_BUILD_TYPE=Release ..
+  - cmake --build . --config Release


### PR DESCRIPTION
This PR adds a [Travis](https://travis-ci.com) config which builds the third party libraries on both Mac and Linux. 

Build result: https://travis-ci.com/judge2020/panda3d-thirdparty/builds/75767634

Regarding windows CI, I attempted to set up Appveyor [here](https://ci.appveyor.com/project/judge2020/panda3d-thirdparty/build/1.0.3), however there is an issue with the installed cmake 3.11 which causes OpenAL to fail, which will likely be fixed with a solution to #1.