### PR TITLE
Miscellaneous macOS fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,8 @@ cmake_minimum_required(VERSION 2.8.3)
 
 # Set defaults.  Must be before project().
 if(APPLE)
-  set(CMAKE_OSX_ARCHITECTURES "x86_64;i386" CACHE STRING "")
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.6" CACHE STRING "")
-  set(CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${CMAKE_OSX_DEPLOYMENT_TARGET}.sdk/ CACHE PATH "")
+  set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "")
 endif()
 
 project(panda3d-thirdparty)
@@ -492,7 +491,7 @@ if(BUILD_ARTOOLKIT)
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_LIST_DIR}/artoolkit.cmake <SOURCE_DIR>/CMakeLists.txt
           COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_LIST_DIR}/artoolkit-config.h.cmake <SOURCE_DIR>/include/AR/config.h.cmake
 
-    CMAKE_ARGS ${COMMON_CMAKE_ARGS} -DCMAKE_OSX_ARCHITECTURES=i386$<SEMICOLON>x86_64
+    CMAKE_ARGS ${COMMON_CMAKE_ARGS}
     INSTALL_DIR ${THIRDPARTY_DIR}/artoolkit
   )
 endif()
@@ -600,23 +599,11 @@ elseif(BUILD_OPENSSL AND APPLE)
                 -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
 
   if(CMAKE_OSX_SYSROOT)
-    set(ssl_flags ${ssl_flags} -isysroot=${CMAKE_OSX_SYSROOT} -I/usr/include)
+    set(ssl_flags ${ssl_flags} -I/usr/include)
   endif()
 
   ExternalProject_Add(
-    openssl-i386
-    URL https://www.openssl.org/source/openssl-1.0.2r.tar.gz
-    URL_HASH SHA256=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
-
-    CONFIGURE_COMMAND /usr/bin/perl ./Configure darwin-i386-cc ${ssl_flags}
-    BUILD_COMMAND make build_libs
-    BUILD_IN_SOURCE 1
-
-    INSTALL_COMMAND ""
-  )
-  ExternalProject_Add(
     openssl
-    DEPENDS openssl-i386
     URL https://www.openssl.org/source/openssl-1.0.2r.tar.gz
     URL_HASH SHA256=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
 
@@ -630,10 +617,8 @@ elseif(BUILD_OPENSSL AND APPLE)
     COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/include "${THIRDPARTY_DIR}/openssl/include"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${THIRDPARTY_DIR}/openssl/lib"
     COMMAND lipo -create -output "${THIRDPARTY_DIR}/openssl/lib/libcrypto.a"
-            -arch i386 "${CMAKE_CURRENT_BINARY_DIR}/openssl-i386-prefix/src/openssl-i386/libcrypto.a"
             -arch x86_64 "${CMAKE_CURRENT_BINARY_DIR}/openssl-prefix/src/openssl/libcrypto.a"
     COMMAND lipo -create -output "${THIRDPARTY_DIR}/openssl/lib/libssl.a"
-            -arch i386 "${CMAKE_CURRENT_BINARY_DIR}/openssl-i386-prefix/src/openssl-i386/libssl.a"
             -arch x86_64 "${CMAKE_CURRENT_BINARY_DIR}/openssl-prefix/src/openssl/libssl.a"
     DEPENDEES install
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,9 +256,25 @@ if(BUILD_HARFBUZZ)
 endif()
 
 if(BUILD_FREETYPE)
+  if(APPLE)
+    # Apple's bundled libicucore.dylib appears to be private, so we'll need to
+    # build our own.
+    ExternalProject_Add(
+      icu
+      URL https://github.com/unicode-org/icu/releases/download/release-64-2/icu4c-64_2-src.tgz
+      URL_HASH SHA256=627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c
+
+      CONFIGURE_COMMAND "../icu/source/configure"
+      BUILD_COMMAND "make"
+      INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/icu
+    )
+    set(icu_dep "icu")
+    set(icu_lib_hint "-DPC_HARFBUZZ_ICU_LIBDIR=${THIRDPARTY_DIR}/icu/lib")
+  endif()
+
   ExternalProject_Add(
     freetype
-    DEPENDS zlib png harfbuzz
+    DEPENDS zlib png harfbuzz ${icu_dep}
     URL https://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.gz
     URL_HASH SHA256=162ef25aa64480b1189cdb261228e6c5c44f212aac4b4621e28cf2157efb59f5
 
@@ -270,6 +286,7 @@ if(BUILD_FREETYPE)
       -DHARFBUZZ_INCLUDE_DIRS=${THIRDPARTY_DIR}/harfbuzz/include
       -DPC_HARFBUZZ_INCLUDEDIR=${THIRDPARTY_DIR}/harfbuzz/include
       -DPC_HARFBUZZ_LIBDIR=${THIRDPARTY_DIR}/harfbuzz/lib
+      ${icu_lib_hint}
     INSTALL_DIR ${THIRDPARTY_DIR}/freetype
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ cmake_minimum_required(VERSION 2.8.3)
 # Set defaults.  Must be before project().
 if(APPLE)
   set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "")
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7" CACHE STRING "")
+  SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 endif()
 
 project(panda3d-thirdparty)


### PR DESCRIPTION
This PR removes the 32-bit build options since we're not longer supporting it as of 1.11 (and it adds some complexity to the build). I also removed the explicit setting of `CMAKE_OSX_SYSROOT` since CMake can infer it from the deployment target.

It also explicitly downloads and builds the `icu` library since there doesn't seem to be an easy way to satisfy that dependency externally.